### PR TITLE
Require refinerycms-settings

### DIFF
--- a/lib/refinery/mailchimp.rb
+++ b/lib/refinery/mailchimp.rb
@@ -1,4 +1,5 @@
 require 'refinerycms-core'
+require 'refinerycms-settings'
 
 module Refinery
   autoload :MailchimpGenerator, 'generators/refinery/mailchimp/mailchimp_generator'


### PR DESCRIPTION
When the user does not require refinerycms-settings in their gem file it threw an error that Refinery::Setting was not defined. By requiring it here this error can be prevented.
