### PR TITLE
Remove recipient name

### DIFF
--- a/app/controllers/refinery/mailchimp/admin/campaigns_controller.rb
+++ b/app/controllers/refinery/mailchimp/admin/campaigns_controller.rb
@@ -12,9 +12,8 @@ module Refinery
         before_filter :fully_qualify_links, :only => [:create, :update]
 
         def new
-          @campaign = ::Refinery::Mailchimp::Campaign.new :to_name => ::Refinery::Setting.get_or_set(Refinery::Mailchimp::API::DefaultToNameSetting[:name], Refinery::Mailchimp::API::DefaultToNameSetting[:default]),
-                                  :from_name => ::Refinery::Setting.get_or_set(Refinery::Mailchimp::API::DefaultFromNameSetting[:name], Refinery::Mailchimp::API::DefaultFromNameSetting[:default]),
-                                  :from_email => ::Refinery::Setting.get_or_set(Refinery::Mailchimp::API::DefaultFromEmailSetting[:name], Refinery::Mailchimp::API::DefaultFromEmailSetting[:default])
+          @campaign = ::Refinery::Mailchimp::Campaign.new :from_name => ::Refinery::Setting.get_or_set(Refinery::Mailchimp::API::DefaultFromNameSetting[:name], Refinery::Mailchimp::API::DefaultFromNameSetting[:default]),
+                                                          :from_email => ::Refinery::Setting.get_or_set(Refinery::Mailchimp::API::DefaultFromEmailSetting[:name], Refinery::Mailchimp::API::DefaultFromEmailSetting[:default])
         end
 
         def send_options

--- a/app/models/refinery/mailchimp/campaign.rb
+++ b/app/models/refinery/mailchimp/campaign.rb
@@ -6,9 +6,9 @@ module Refinery
 
       self.table_name = 'refinery_mailchimp_campaigns'
 
-      attr_accessible :to_name, :from_name, :from_email, :subject, :body, :mailchimp_list_id, :mailchimp_template_id, :auto_tweet
+      attr_accessible :from_name, :from_email, :subject, :body, :mailchimp_list_id, :mailchimp_template_id, :auto_tweet
 
-      validates_presence_of :subject, :body, :mailchimp_list_id, :from_email, :from_name, :to_name
+      validates_presence_of :subject, :body, :mailchimp_list_id, :from_email, :from_name
 
       before_save :update_mailchimp_campaign
       before_create :create_mailchimp_campaign
@@ -63,10 +63,9 @@ module Refinery
     protected
 
       def create_mailchimp_campaign
-        options = { :subject => subject, :from_email => from_email, :from_name => from_name, :to_name => to_name, :list_id => mailchimp_list_id, :auto_tweet => auto_tweet }
+        options = { :subject => subject, :from_email => from_email, :from_name => from_name, :list_id => mailchimp_list_id, :auto_tweet => auto_tweet }
         options[:template_id] = mailchimp_template_id unless mailchimp_template_id.blank?
-        # options[:analytics] = { :google => google_analytics } unless google_analytics.blank?
-
+        
         self.mailchimp_campaign_id = begin
           Refinery::Mailchimp::API.new.campaign_create 'regular', options, { content_key => body }
         rescue Hominid::APIError
@@ -81,7 +80,7 @@ module Refinery
 
         client = Refinery::Mailchimp::API.new
 
-        options = {:title => :subject, :from_email => :from_email, :from_name => :from_name, :to_name => :to_name, :list_id => :mailchimp_list_id, :template_id => :mailchimp_template_id, :content => :body, :auto_tweet => :auto_tweet }
+        options = {:title => :subject, :from_email => :from_email, :from_name => :from_name, :list_id => :mailchimp_list_id, :template_id => :mailchimp_template_id, :content => :body, :auto_tweet => :auto_tweet }
         options.each_pair do |option_name, attribute|
           if changed.include?(attribute.to_s)
             success = client.campaign_update mailchimp_campaign_id, option_name, (option_name == :content ? { content_key => body } : self.send(attribute))

--- a/app/views/refinery/mailchimp/admin/campaigns/_form.html.erb
+++ b/app/views/refinery/mailchimp/admin/campaigns/_form.html.erb
@@ -22,14 +22,6 @@
 
     <div class='field'>
       <span class='label_with_help'>
-        <%= f.label :to_name, t('.to_name') -%>
-        <%= refinery_help_tag t('.to_name_help') %>
-      </span>
-      <%= f.text_field :to_name %>
-    </div>
-
-    <div class='field'>
-      <span class='label_with_help'>
         <%= f.label :from_name, t('.from_name') -%>
         <%= refinery_help_tag t('.from_name_help') %>
       </span>

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -40,7 +40,7 @@ nl:
             form:
               subject: Onderwerp
               body: Body
-              to_and_from: Ontvanger en afzender
+              from: Afzender
               settings: Instellingen
               subject_help: Het onderwerp dat gebruikt word voor de campagne emails.
               mailchimp_list_id: Mailing lijst

--- a/db/migrate/2_remove_to_name_from_mailchimp_campaigns.rb
+++ b/db/migrate/2_remove_to_name_from_mailchimp_campaigns.rb
@@ -1,0 +1,11 @@
+class RemoveToNameFromMailchimpCampaigns < ActiveRecord::Migration
+
+  def up
+    remove_column :refinery_mailchimp_campaigns, :to_name
+  end
+
+  def down
+    add_column :refinery_mailchimp_campaigns, :to_name, :string
+  end
+
+end

--- a/lib/refinery/mailchimp.rb
+++ b/lib/refinery/mailchimp.rb
@@ -1,4 +1,5 @@
 require 'refinerycms-core'
+require 'refinerycms-settings'
 
 module Refinery
   autoload :MailchimpGenerator, 'generators/refinery/mailchimp/mailchimp_generator'

--- a/lib/refinery/mailchimp/engine.rb
+++ b/lib/refinery/mailchimp/engine.rb
@@ -31,7 +31,6 @@ module Refinery
       KeySetting = { :name => "mailchimp_api_key", :default => "Set me!" }
       DefaultFromNameSetting = { :name => "mailchimp_default_from_name", :default => "" }
       DefaultFromEmailSetting = { :name => "mailchimp_default_from_email", :default => "" }
-      DefaultToNameSetting = { :name => "mailchimp_default_to_name", :default => "" }
 
       class BadAPIKeyError < StandardError; end
 

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :campaign, :class => Refinery::Mailchimp::Campaign do |f|
     f.sequence(:subject) { |n| "See our #{n} newest site additions!" }
     f.body "Here's a campaign body!"
-    f.to_name "Jimmy"
     f.from_name "Johnny"
     f.from_email "Johnson"
     f.mailchimp_list_id "ah23jxj"


### PR DESCRIPTION
It makes no sence to fill in one name thats used for all recipients, if a name is known in the mailchimp database it should be used, and otherwise no name at all should be used.
