### PR TITLE
Update branch name for gem installation in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ To set up a Refinery app from scratch, you'll need to install Refinery and creat
 
 Once you have a Refinery app created, add this engine to your Gemfile in the `USER DEFINED` area:
 
-    gem 'refinerycms-mailchimp', :github => 'Wirelab/refinerycms-mailchimp', :branch => 'feature/2.0.0'
+    gem 'refinerycms-mailchimp', :github => 'Wirelab/refinerycms-mailchimp', :branch => 'refinery-2.1'
 
 Then, from the command line:
 


### PR DESCRIPTION
Update the branch name in the README instructions for gem installation so no errors are thrown when running bundle install.
